### PR TITLE
Refactory Enum and changed variables names

### DIFF
--- a/lib/demo/coinbase.ex
+++ b/lib/demo/coinbase.ex
@@ -18,30 +18,26 @@ defmodule Demo.Coinbase do
   def product(id) do
     get("products/" <> id <> "/ticker")
     |> parse_response()
-    |> aggregate_id(id)
+    |> add_id(id)
   end
 
   defp tickers_list(products) do
-    Enum.reduce(products, [], fn product, list ->
-      fetch_products_tickers(product)
+    Enum.reduce(products, [], fn %{"id" => id}, list ->
+      product(id)
       |> parse_products_tickers(list)
     end)
   end
 
-  defp aggregate_id({:ok, ticker}, id) do
+  defp add_id({:ok, ticker}, id) do
     {:ok, Map.merge(ticker, %{"id" => id})}
   end
 
-  defp aggregate_id(error, _), do: error
+  defp add_id(error, _), do: error
 
   defp parse_products_tickers({:ok, ticker}, list),
-    do: list ++ [ticker]
+    do: [ticker | list]
 
   defp parse_products_tickers(_, list), do: list
-
-  defp fetch_products_tickers(%{"id" => id}), do: product(id)
-
-  defp fetch_products_tickers(error), do: error
 
   defp parse_response({:ok, %Tesla.Env{status: 200, body: body}}),
     do: {:ok, body}

--- a/lib/demo/tracker.ex
+++ b/lib/demo/tracker.ex
@@ -35,7 +35,7 @@ defmodule Demo.Tracker do
   end
 
   def update_state(state) do
-    with {:ok, result} <- Coinbase.products() do
+    with {:ok, result} <- Coinbase.products_ticker() do
       [result | state]
     else
       _ -> state

--- a/lib/demo/tracker.ex
+++ b/lib/demo/tracker.ex
@@ -29,7 +29,7 @@ defmodule Demo.Tracker do
 
     [head | _] = state
 
-    broadcast({:ok, head}, :last_conversion_rates)
+    broadcast({:ok, head}, :new_rates)
     Process.send_after(self(), :work, 5000)
     {:noreply, state}
   end

--- a/lib/demo_web/live/tracker_live.ex
+++ b/lib/demo_web/live/tracker_live.ex
@@ -19,9 +19,7 @@ defmodule DemoWeb.TrackerLive do
     {:noreply, socket}
   end
 
-  @spec handle_info({:last_conversion_rates, any}, Phoenix.LiveView.Socket.t()) ::
-          {:noreply, Phoenix.LiveView.Socket.t()}
-  def handle_info({:last_conversion_rates, result}, socket) do
+  def handle_info({:new_rates, result}, socket) do
     socket = assign(socket, :conversions, result)
     {:noreply, socket}
   end


### PR DESCRIPTION
Refactor `Enum.reduce` because the function was doing too many things
 - Created new function `tickers_list` to put `Enum.reduce` logic

Some variables name weren't explicit
 - Changed the name for better read of the code
